### PR TITLE
Improve Find command 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,10 +63,10 @@ In a conventional application cycle, the large influx of applicants makes it cha
 
 ### 4. Delete applicants: `delete`
 
-- Format: `delete n/NAME p/PHONE_NUMBER`
+- Format: `delete TARGET_INDEX`
 
 - Examples:
-    - `delete n/Jack Dill p/PHONE_NUMBER`
+    - `delete 1`
 
 ### 5. Advancing an applicant's status: `advance`
 
@@ -108,9 +108,9 @@ Find applicants using keywords (name OR phone number OR both)
 ## Command Summary
 
 | Action  | Format, Examples                                                                                                                                                        |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Add     | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [note/NOTES]…`<br>Example: `add n/James Ho p/91234567 e/jamesho@example.com a/123, Clementi Rd, 1234665 note/Entrepreneur` |
-| Delete  | `delete n/NAME p/PHONE_NUMBER`<br>Example: `delete n/James Ho p/91234567`                                                                                               |
+| Delete  | `delete TARGET_INDEX`<br>Example: `delete 1`                                                                                                                            |
 | Edit    | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…`<br>Example: `edit 2 n/James Lee e/jameslee@example.com`                                           |
 | List    | `list`                                                                                                                                                                  |
 | Help    | `help`                                                                                                                                                                  |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -90,8 +90,18 @@ Rejects a candidate or interviewee
 - Format: `reject n/NAME p/PHONE_NUMBER`
 
 - Examples:
-
     - `reject n/Jack Dill p/91234567`
+
+### 7. Find an applicant: `find`
+
+Find applicants using keywords (name OR phone number OR both)
+
+- Format:
+  - Format 1: `find NAME or PHONE NUMBER` (only need to provide either one)
+  - Format 2: `find n/NAME p/PHONE NUMBER` (must provide both)
+- Example: 
+  - Example 1: `find Jack Dill`, `find 91234567`
+  - Example 2: `find n/Jack Dill p/91234567`
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -44,7 +44,7 @@ In a conventional application cycle, the large influx of applicants makes it cha
 | Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>e.g. if the command specifies `help 123`, it will be interpreted as `help`.                     |
 
 ---
-
+// Additional features: can list out the tag(skillset) of the applicants.
 ### **Command**
 
 ### 1. Viewing help: `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,10 +63,10 @@ In a conventional application cycle, the large influx of applicants makes it cha
 
 ### 4. Delete applicants: `delete`
 
-- Format: `delete TARGET_INDEX`
+- Format: `delete n/NAME p/PHONE_NUMBER`
 
 - Examples:
-    - `delete 1`
+    - `delete n/Jack Dill p/PHONE_NUMBER`
 
 ### 5. Advancing an applicant's status: `advance`
 
@@ -108,9 +108,9 @@ Find applicants using keywords (name OR phone number OR both)
 ## Command Summary
 
 | Action  | Format, Examples                                                                                                                                                        |
-| ------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Add     | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [note/NOTES]…`<br>Example: `add n/James Ho p/91234567 e/jamesho@example.com a/123, Clementi Rd, 1234665 note/Entrepreneur` |
-| Delete  | `delete TARGET_INDEX`<br>Example: `delete 1`                                                                                                                            |
+| Delete  | `delete n/NAME p/PHONE_NUMBER`<br>Example: `delete n/James Ho p/91234567`                                                                                               |
 | Edit    | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…`<br>Example: `edit 2 n/James Lee e/jameslee@example.com`                                           |
 | List    | `list`                                                                                                                                                                  |
 | Help    | `help`                                                                                                                                                                  |

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -19,16 +20,25 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private NameContainsKeywordsPredicate namePredicate = null;
+    private PhoneContainsKeywordsPredicate phonePredicate = null;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(NameContainsKeywordsPredicate namePredicate) {
+        this.namePredicate = namePredicate;
+    }
+
+    public FindCommand(PhoneContainsKeywordsPredicate phonePredicate) {
+        this.phonePredicate = phonePredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        if (namePredicate == null) {
+            model.updateFilteredPersonList(phonePredicate);
+        } else {
+            model.updateFilteredPersonList(namePredicate);
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -37,6 +47,8 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && namePredicate.equals(((FindCommand) other).namePredicate))
+                || (other instanceof FindCommand
+                && phonePredicate.equals(((FindCommand) other).phonePredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -59,8 +59,6 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && namePredicate.equals(((FindCommand) other).namePredicate))
-                || (other instanceof FindCommand
-                && phonePredicate.equals(((FindCommand) other).phonePredicate)); // state check
+                && namePredicate.equals(((FindCommand) other).namePredicate));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.NameAndPhoneContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
@@ -16,12 +17,16 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "the specified keywords such as name, phone number or both (case-insensitive) and displays them as a "
+            + "list with index numbers.\n"
+            + "Parameters: Format 1: KEYWORDS(either NAME or PHONE NUMBER);\n "
+            + "Format 2: n/NAME p/PHONE NUMBER(both must referring to the same person)\n"
+            + "Example for Format 1: " + COMMAND_WORD + " alice bob charlie OR 12345678\n"
+            + "Example for Format 2: " + COMMAND_WORD + "n/alice bob p/12345678";
 
     private NameContainsKeywordsPredicate namePredicate = null;
     private PhoneContainsKeywordsPredicate phonePredicate = null;
+    private NameAndPhoneContainsKeywordsPredicate nameAndPhoneContainsKeywordsPredicate = null;
 
     public FindCommand(NameContainsKeywordsPredicate namePredicate) {
         this.namePredicate = namePredicate;
@@ -31,13 +36,20 @@ public class FindCommand extends Command {
         this.phonePredicate = phonePredicate;
     }
 
+    public FindCommand(NameAndPhoneContainsKeywordsPredicate nameAndPhoneContainsKeywordsPredicate) {
+        this.nameAndPhoneContainsKeywordsPredicate = nameAndPhoneContainsKeywordsPredicate;
+    }
+
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (namePredicate == null) {
-            model.updateFilteredPersonList(phonePredicate);
-        } else {
+        if (nameAndPhoneContainsKeywordsPredicate != null) {
+            model.updateFilteredPersonList(nameAndPhoneContainsKeywordsPredicate);
+        } else if (namePredicate != null) {
             model.updateFilteredPersonList(namePredicate);
+        } else {
+            model.updateFilteredPersonList(phonePredicate);
         }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -26,7 +27,18 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
+//        String[] phoneKeywords = trimmedArgs.split("")
 
+        if (nameKeywords.length == 1) {
+            String nameOrPhone = nameKeywords[0];
+            char firstChar = nameOrPhone.charAt(0);
+            //Check the input value is Integer or String
+            //String means the keyword is Applicant's name
+            //integer means the keyword is Applicant's phone number
+            if (Character.isDigit(firstChar)) {
+                return new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            }
+        }
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,13 +1,22 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.NameAndPhoneContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Phone;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+
+
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -20,26 +29,49 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE);
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-//        String[] phoneKeywords = trimmedArgs.split("")
 
-        if (nameKeywords.length == 1) {
-            String nameOrPhone = nameKeywords[0];
-            char firstChar = nameOrPhone.charAt(0);
-            //Check the input value is Integer or String
-            //String means the keyword is Applicant's name
-            //integer means the keyword is Applicant's phone number
-            if (Character.isDigit(firstChar)) {
-                return new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+
+        if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)) {
+            //Means both applicant's name and phone number are given
+
+            Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            String[] nameKeywords = name.fullName.split("\\s+");
+            String[] phoneKeywords = phone.value.split("\\s+");
+            String[] combinedKeywords = Arrays.copyOf(nameKeywords, nameKeywords.length + phoneKeywords.length);
+            System.arraycopy(phoneKeywords, 0, combinedKeywords, nameKeywords.length, phoneKeywords.length);
+
+            return new FindCommand(new NameAndPhoneContainsKeywordsPredicate(Arrays.asList(combinedKeywords)));
+
+        } else {
+            String trimmedArgs = args.trim();
+            if (trimmedArgs.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
+
+            String[] keywords = trimmedArgs.split("\\s+");
+
+
+            if (keywords.length == 1) {
+                String nameOrPhone = keywords[0];
+                char firstChar = nameOrPhone.charAt(0);
+                if (Character.isDigit(firstChar)) {
+                    return new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
+                }
+            }
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         }
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/model/person/NameAndPhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameAndPhoneContainsKeywordsPredicate.java
@@ -1,0 +1,26 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} and {@code Phone Number} match any of the keywords given.
+ */
+
+public class NameAndPhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywordsContainsNameAndPhone;
+
+    public NameAndPhoneContainsKeywordsPredicate(List<String> keywordsContainsNameAndPhone) {
+        this.keywordsContainsNameAndPhone = keywordsContainsNameAndPhone;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        boolean result = keywordsContainsNameAndPhone.stream()
+                .allMatch(keyword -> (StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword))
+                        || (StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword)));
+        return result;
+    }
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone Number} matches any of the keywords given.
+ */
+
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof PhoneContainsKeywordsPredicate
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords));
+    }
+}


### PR DESCRIPTION
Augment FindCommand applicants using keywords (name OR phone number OR both)

- Format:
  - Format 1: `find NAME or PHONE NUMBER` (only need to provide either one)
  - Format 2: `find n/NAME p/PHONE NUMBER` (must provide both)
- Example: 
  - Example 1: `find Jack Dill`, `find 91234567`
  - Example 2: `find n/Jack Dill p/91234567`

FYI: If the user provided both applicant's name and phone number but without following strictly the format n/NAME p/PHONE NUMBER, this function will still filter the applicant but is based on the name provided and ignore the phone number.