### PR TITLE
DateTimeParser to help format interview dates

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,4 +10,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_NO_PERSON_WITH_NAME_AND_PHONE = "No person with name and phone found!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_DATETIME = "Invalid date and time provided";
 }

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
@@ -23,19 +26,22 @@ public class AdvanceCommand extends Command {
             + PREFIX_PHONE + "PHONE\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 ";
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_DATETIME + "08/03/2023 18:00";
 
     private final NamePhoneNumberPredicate predicate;
+    private final LocalDateTime interviewDateTime;
 
     /**
      * Creates an AdvanceCommand to advance the specified {@code Person}
      */
-    public AdvanceCommand(NamePhoneNumberPredicate predicate) {
+    public AdvanceCommand(NamePhoneNumberPredicate predicate, LocalDateTime interviewDateTime) {
         this.predicate = predicate;
+        this.interviewDateTime = interviewDateTime;
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
 
@@ -43,7 +49,12 @@ public class AdvanceCommand extends Command {
         assert personList.size() <= 1;
 
         if (personList.size() < 1) {
-            return new CommandResult(Messages.MESSAGE_NO_PERSON_WITH_NAME_AND_PHONE);
+            throw new CommandException(Messages.MESSAGE_NO_PERSON_WITH_NAME_AND_PHONE);
+        }
+        // Check if the interviewDateTime is nonNull else throw CommandException
+        // See if we want to provide the d/ field for all advance commands
+        if (interviewDateTime == null) {
+            throw new CommandException("No interview datetime provided!");
         }
 
         Person personToAdvance = personList.get(0);

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -5,12 +5,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.InterviewDateTime;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
 
@@ -27,15 +27,15 @@ public class AdvanceCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
-            + PREFIX_DATETIME + "08/03/2023 18:00";
+            + PREFIX_DATETIME + "08-03-2023 18:00";
 
     private final NamePhoneNumberPredicate predicate;
-    private final LocalDateTime interviewDateTime;
+    private final InterviewDateTime interviewDateTime;
 
     /**
      * Creates an AdvanceCommand to advance the specified {@code Person}
      */
-    public AdvanceCommand(NamePhoneNumberPredicate predicate, LocalDateTime interviewDateTime) {
+    public AdvanceCommand(NamePhoneNumberPredicate predicate, InterviewDateTime interviewDateTime) {
         this.predicate = predicate;
         this.interviewDateTime = interviewDateTime;
     }
@@ -60,6 +60,7 @@ public class AdvanceCommand extends Command {
         Person personToAdvance = personList.get(0);
         if (model.advancePerson(personToAdvance)) {
             model.refreshListWithPredicate(predicate);
+            personToAdvance.setInterviewDateTime(interviewDateTime);
             return new CommandResult("Successfully advanced " + personToAdvance.getName().fullName);
         } else {
             return new CommandResult(personToAdvance.getName().fullName + " cannot be advanced!");

--- a/src/main/java/seedu/address/logic/parser/AdvanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AdvanceCommandParser.java
@@ -5,11 +5,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AdvanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.InterviewDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Phone;
@@ -33,7 +33,7 @@ public class AdvanceCommandParser implements Parser<AdvanceCommand> {
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        LocalDateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
+        InterviewDateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
 
         return new AdvanceCommand(new NamePhoneNumberPredicate(name, phone), dateTime);
     }

--- a/src/main/java/seedu/address/logic/parser/AdvanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AdvanceCommandParser.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AdvanceCommand;
@@ -22,17 +24,18 @@ public class AdvanceCommandParser implements Parser<AdvanceCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AdvanceCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_DATETIME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_DATETIME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AdvanceCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        LocalDateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
 
-        return new AdvanceCommand(new NamePhoneNumberPredicate(name, phone));
+        return new AdvanceCommand(new NamePhoneNumberPredicate(name, phone), dateTime);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_NOTE = new Prefix("note/");
+    public static final Prefix PREFIX_DATETIME = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -20,7 +20,7 @@ public class DateTimeParser {
      */
     public static LocalDateTime parseDateTime(String dateTimeString) throws ParseException {
         // Format DD/MM/YYYY HH:MM
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("DD/MM/YYYY HH:MM");
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
         try {
             return LocalDateTime.parse(dateTimeString, format);
         } catch (DateTimeParseException e) {

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -20,7 +20,10 @@ public class DateTimeParser {
      */
     public static LocalDateTime parseDateTime(String dateTimeString) throws ParseException {
         // Format DD/MM/YYYY HH:MM
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        if (dateTimeString.length() == 0) {
+            return null;
+        }
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
         try {
             return LocalDateTime.parse(dateTimeString, format);
         } catch (DateTimeParseException e) {
@@ -34,6 +37,6 @@ public class DateTimeParser {
      * @return String output of the datetime.
      */
     public static String datetimeFormatter(LocalDateTime datetime) {
-        return datetime.format(DateTimeFormatter.ofPattern("DD/MM/YYYY HH:mm"));
+        return datetime.format(DateTimeFormatter.ofPattern("DD-MM-YYYY HH:mm"));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parses input arguments and creates a new LocalDateTime object
+ */
+public class DateTimeParser {
+    /**
+     * Static method to format datetime string into a LocalDateTime object.
+     * @param dateTimeString String input for datetime.
+     * @return LocalDateTime object representing the current datetime.
+     * @throws ParseException If the input is not in the write format to be converted.
+     */
+    public static LocalDateTime parseDateTime(String dateTimeString) throws ParseException {
+        // Format DD/MM/YYYY HH:MM
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("DD/MM/YYYY HH:MM");
+        try {
+            return LocalDateTime.parse(dateTimeString, format);
+        } catch (DateTimeParseException e) {
+            throw new ParseException(Messages.MESSAGE_INVALID_DATETIME);
+        }
+    }
+
+    /**
+     * Takes in the dateTime object to produce the right format to show to the User.
+     * @param datetime LocalDateTime object
+     * @return String output of the datetime.
+     */
+    public static String datetimeFormatter(LocalDateTime datetime) {
+        return datetime.format(DateTimeFormatter.ofPattern("DD/MM/YYYY HH:mm"));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -19,7 +19,7 @@ public class DateTimeParser {
      * @throws ParseException If the input is not in the write format to be converted.
      */
     public static LocalDateTime parseDateTime(String dateTimeString) throws ParseException {
-        // Format DD/MM/YYYY HH:MM
+        // Format DD-MM-YYYY HH:MM
         if (dateTimeString.length() == 0) {
             return null;
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -120,5 +121,17 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String dateTime} into an {@code LocalDateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dateTime} is invalid.
+     */
+    public static LocalDateTime parseDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        return DateTimeParser.parseDateTime(trimmedDateTime);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -12,6 +11,7 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -129,9 +129,10 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dateTime} is invalid.
      */
-    public static LocalDateTime parseDateTime(String dateTime) throws ParseException {
+    public static InterviewDateTime parseDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);
         String trimmedDateTime = dateTime.trim();
-        return DateTimeParser.parseDateTime(trimmedDateTime);
+        InterviewDateTime interviewDateTime = new InterviewDateTime(trimmedDateTime);
+        return interviewDateTime;
     }
 }

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -1,0 +1,22 @@
+package seedu.address.model.person;
+
+import java.time.LocalDateTime;
+
+import seedu.address.logic.parser.DateTimeParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Represents a Person's interview date and time in the address book.
+ * Guarantees: interview's date and time are valid
+ */
+public class InterviewDateTime {
+    private static LocalDateTime dateTime;
+    public InterviewDateTime(String dateTime) throws ParseException {
+        this.dateTime = DateTimeParser.parseDateTime(dateTime);
+    }
+    @Override
+    public String toString() {
+        return DateTimeParser.datetimeFormatter(dateTime);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,9 +2,12 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.tag.Tag;
@@ -24,6 +27,7 @@ public class Person {
     private final Address address;
     private Status status;
     private final Set<Tag> notes = new HashSet<>();
+    private Optional<LocalDateTime> interviewDateTime = Optional.empty();
 
     /**
      * Every field must be present and not null.
@@ -64,6 +68,23 @@ public class Person {
      */
     public Set<Tag> getNotes() {
         return Collections.unmodifiableSet(notes);
+    }
+
+    /**
+     * Returns the interview dateTime for the applicant if present, else throws {@code NoSuchElementException}
+     * @return Interview date of the applicant.
+     * @throws NoSuchElementException Thrown when no interview date is present.
+     */
+    public LocalDateTime getInterviewDateTime() throws NoSuchElementException {
+        return interviewDateTime.orElseThrow();
+    }
+
+    /**
+     * Sets interview dateTime for shortlisted applicants.
+     * @param interviewDateTime Interview dateTime for the applicant.
+     */
+    public void setInterviewDateTime(LocalDateTime interviewDateTime) {
+        this.interviewDateTime = Optional.of(interviewDateTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
@@ -27,7 +26,7 @@ public class Person {
     private final Address address;
     private Status status;
     private final Set<Tag> notes = new HashSet<>();
-    private Optional<LocalDateTime> interviewDateTime = Optional.empty();
+    private Optional<InterviewDateTime> interviewDateTime = Optional.empty();
 
     /**
      * Every field must be present and not null.
@@ -75,7 +74,7 @@ public class Person {
      * @return Interview date of the applicant.
      * @throws NoSuchElementException Thrown when no interview date is present.
      */
-    public LocalDateTime getInterviewDateTime() throws NoSuchElementException {
+    public InterviewDateTime getInterviewDateTime() throws NoSuchElementException {
         return interviewDateTime.orElseThrow();
     }
 
@@ -83,7 +82,7 @@ public class Person {
      * Sets interview dateTime for shortlisted applicants.
      * @param interviewDateTime Interview dateTime for the applicant.
      */
-    public void setInterviewDateTime(LocalDateTime interviewDateTime) {
+    public void setInterviewDateTime(InterviewDateTime interviewDateTime) {
         this.interviewDateTime = Optional.of(interviewDateTime);
     }
 
@@ -162,5 +161,4 @@ public class Person {
         }
         return builder.toString();
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class DateTimeParserTest {
-    private DateTimeParser dateTimeParser = new DateTimeParser();
-    private LocalDateTime template = LocalDateTime.of(2023, 02, 12, 18, 0);
+    private final LocalDateTime template = LocalDateTime.of(2023, 02, 12, 18, 0);
 
     @Test
     public void createDateTime_validFormat() {
@@ -25,9 +24,6 @@ public class DateTimeParserTest {
 
     @Test
     public void createDateTime_invalidFormat_parseExceptionThrown() {
-        assertThrows(ParseException.class, () -> {
-            DateTimeParser.parseDateTime("2020/02/12 18:00");
-        });
+        assertThrows(ParseException.class, () -> DateTimeParser.parseDateTime("2020/02/12 18:00"));
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class DateTimeParserTest {
+    private DateTimeParser dateTimeParser = new DateTimeParser();
+    private LocalDateTime template = LocalDateTime.of(2023, 02, 12, 18, 0);
+
+    @Test
+    public void createDateTime_validFormat() {
+        try {
+            LocalDateTime dateTime = DateTimeParser.parseDateTime("12/02/2023 18:00");
+            assertEquals(template, dateTime);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void createDateTime_invalidFormat_parseExceptionThrown() {
+        assertThrows(ParseException.class, () -> {
+            DateTimeParser.parseDateTime("2020/02/12 18:00");
+        });
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -15,7 +15,7 @@ public class DateTimeParserTest {
     @Test
     public void createDateTime_validFormat() {
         try {
-            LocalDateTime dateTime = DateTimeParser.parseDateTime("12/02/2023 18:00");
+            LocalDateTime dateTime = DateTimeParser.parseDateTime("12-02-2023 18:00");
             assertEquals(template, dateTime);
         } catch (ParseException e) {
             e.printStackTrace();
@@ -24,6 +24,6 @@ public class DateTimeParserTest {
 
     @Test
     public void createDateTime_invalidFormat_parseExceptionThrown() {
-        assertThrows(ParseException.class, () -> DateTimeParser.parseDateTime("2020/02/12 18:00"));
+        assertThrows(ParseException.class, () -> DateTimeParser.parseDateTime("2020-02-12 18:00"));
     }
 }


### PR DESCRIPTION
## What?
Adds the `DateTimeParser` class and formats the `AdvanceCommand` to accept a date and time.

## Why
A shortlisted applicant should have an interview date and time.

An interview date provided by `HMHero` might not be valid.

## How
The `interviewDateTime` field is added to the `Person` class.

The `DateTimeParser` class helps to check if the interview date provided by the user is valid.

It also helps format the `interview date: LocalDateTime` into an easily readable string to be output to the user later on.

Fix #40 