### PR TITLE
Add test cases for DateTimeParser and InterviewDateTime classes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -37,6 +37,6 @@ public class DateTimeParser {
      * @return String output of the datetime.
      */
     public static String datetimeFormatter(LocalDateTime datetime) {
-        return datetime.format(DateTimeFormatter.ofPattern("DD-MM-YYYY HH:mm"));
+        return datetime.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
     }
 }

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -19,4 +19,11 @@ public class InterviewDateTime {
     public String toString() {
         return DateTimeParser.datetimeFormatter(dateTime);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewDateTime // instanceof handles nulls
+                && dateTime.equals(((InterviewDateTime) other).dateTime)); // state check
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class DateTimeParserTest {
+    private static final String templateDateTimeString = "12-02-2023 18:00";
     private final LocalDateTime template = LocalDateTime.of(2023, 02, 12, 18, 0);
 
     @Test
@@ -26,4 +27,21 @@ public class DateTimeParserTest {
     public void createDateTime_invalidFormat_parseExceptionThrown() {
         assertThrows(ParseException.class, () -> DateTimeParser.parseDateTime("2020-02-12 18:00"));
     }
+
+    @Test
+    public void createDateTime_emptyString_returnNull() {
+        try {
+            LocalDateTime dateTime = DateTimeParser.parseDateTime("");
+            assertEquals(dateTime, null);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test void dateTimeFormatter_formatsDateTimeInValidFormat() {
+        String formattedDateTime = DateTimeParser.datetimeFormatter(template);
+        assertEquals(formattedDateTime, templateDateTimeString);
+    }
+
+
 }

--- a/src/test/java/seedu/address/model/person/InterviewDateTimeTest.java
+++ b/src/test/java/seedu/address/model/person/InterviewDateTimeTest.java
@@ -1,0 +1,56 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.DateTimeParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class InterviewDateTimeTest {
+    private static final String templateDateTimeString = "12-02-2023 18:00";
+    private static InterviewDateTime template = null;
+
+    static {
+        try {
+            template = new InterviewDateTime(templateDateTimeString);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void createInterviewDateTime_validFormat() {
+        try {
+            LocalDateTime dateTime = DateTimeParser.parseDateTime(templateDateTimeString);
+            assertEquals(template, dateTime);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void createInterviewDateTime_emptyString_returnsNullInterviewDateTime() {
+        try {
+            String interviewDateTime = new InterviewDateTime(InterviewDateTime.EMPTY_DATE_TIME).toString();
+        } catch (ParseException e) {
+            System.out.println("Invalid datetime string provided");
+        } catch (NullPointerException e) {
+            System.out.println("No datetime string provided");
+        }
+    }
+
+    @Test
+    public void checkEqualityOfIdenticalInterviewDateTime() {
+        try {
+            InterviewDateTime interviewDateTime = new InterviewDateTime(templateDateTimeString);
+            boolean equals = interviewDateTime.equals(template);
+            assertEquals(interviewDateTime, template);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
## What
Add test cases for `DateTimeParser` and `InterviewDateTime` classes

## Why
Insufficient test cases for the above mentioned classes

## How
Adds full path coverage for both classes.

## Future Edits
The current implementation of the DateTimeParser does not readily address `ParseException`. Edits to enhance exception handling for both classes should be done for future iterations!
