### PR TITLE
Fix NullPointerException bug

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -119,6 +119,11 @@ class JsonAdaptedPerson {
         }
         final Status modelStatus = Status.valueOf(status);
 
+        if (interviewDate == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    InterviewDateTime.class.getSimpleName()));
+        }
+
         if (!InterviewDateTime.isValidDateTime(interviewDate)) {
             throw new IllegalValueException(InterviewDateTime.MESSAGE_CONSTRAINTS);
         }


### PR DESCRIPTION
## What
Fix bug where missing `interviewDate` field in json file leads to `NullPointerException`

## Why
`JsonAdaptedPerson` was missing a null check for `interviewDate` when converting from json to `Person` object.
Now HMHero should ignore the json file entirely if there is a missing field.