### PR TITLE
Improve FindCommand predicate checking

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -57,8 +57,21 @@ public class FindCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof FindCommand // instanceof handles nulls
-                && namePredicate.equals(((FindCommand) other).namePredicate));
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof FindCommand)) {
+            return false;
+        }
+        FindCommand otherCmd = (FindCommand) other;
+        boolean sameNamePredicate = (namePredicate == null) ? otherCmd.namePredicate == null
+                : namePredicate.equals(((FindCommand) other).namePredicate);
+        boolean samePhonePredicate = (phonePredicate == null) ? otherCmd.phonePredicate == null
+                : phonePredicate.equals(((FindCommand) other).phonePredicate);
+        boolean sameNamePhonePredicate = (nameAndPhoneContainsKeywordsPredicate == null)
+                ? otherCmd.nameAndPhoneContainsKeywordsPredicate == null
+                : nameAndPhoneContainsKeywordsPredicate
+                .equals(((FindCommand) other).nameAndPhoneContainsKeywordsPredicate);
+        return sameNamePredicate && samePhonePredicate && sameNamePhonePredicate;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameAndPhoneContainsKeywordsPredicate;
@@ -64,14 +66,10 @@ public class FindCommand extends Command {
             return false;
         }
         FindCommand otherCmd = (FindCommand) other;
-        boolean sameNamePredicate = (namePredicate == null) ? otherCmd.namePredicate == null
-                : namePredicate.equals(((FindCommand) other).namePredicate);
-        boolean samePhonePredicate = (phonePredicate == null) ? otherCmd.phonePredicate == null
-                : phonePredicate.equals(((FindCommand) other).phonePredicate);
-        boolean sameNamePhonePredicate = (nameAndPhoneContainsKeywordsPredicate == null)
-                ? otherCmd.nameAndPhoneContainsKeywordsPredicate == null
-                : nameAndPhoneContainsKeywordsPredicate
-                .equals(((FindCommand) other).nameAndPhoneContainsKeywordsPredicate);
+        boolean sameNamePredicate = Objects.equals(namePredicate, otherCmd.namePredicate);
+        boolean samePhonePredicate = Objects.equals(phonePredicate, otherCmd.phonePredicate);
+        boolean sameNamePhonePredicate = Objects.equals(nameAndPhoneContainsKeywordsPredicate,
+                otherCmd.nameAndPhoneContainsKeywordsPredicate);
         return sameNamePredicate && samePhonePredicate && sameNamePhonePredicate;
     }
 }


### PR DESCRIPTION
## What
Fix `equals` method which leads to `NullPointerException` during testing.

## Why
`FindCommand` was missing a null check for `equals` method.

## How
Calls `Objects.equals`  method to ensure that `namePredicate` , `phonePredicate`  and `nameAndPhoneContainsPredicate`  is not null so that it can call on `otherCmd` without `NullPointerException`.


Fix: https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/44