### PR TITLE
Create test cases for AdvanceCommandParser

### DIFF
--- a/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AdvanceCommand;
+import seedu.address.model.person.NamePhoneNumberPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class AdvanceCommandParserTest {
+    private AdvanceCommandParser parser = new AdvanceCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAdvanceCommand() {
+        // no leading and trailing whitespaces
+        Person amy = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).build();
+        NamePhoneNumberPredicate predicate = new NamePhoneNumberPredicate(amy.getName(), amy.getPhone());
+        AdvanceCommand expectedAdvanceCommand = new AdvanceCommand(predicate, Optional.empty());
+        assertParseSuccess(parser, " n/Amy Bee p/11111111", expectedAdvanceCommand);
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n n/Amy Bee \n \t p/11111111  \t", expectedAdvanceCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AdvanceCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AdvanceCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
## What
Add test cases for `AdvanceCommandParserTest` class.

## Why
Insufficient test cases for the above mentioned classes and changes were made to enhance code quality.

This ensures that the codebase is operating according to the intended business logic.

## How
Added test cases for public methods in the `AdvanceCommandParser` class.

Fix: https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/53