### PR TITLE
Advance command check clashing interviews

### DIFF
--- a/docs/team/fredericchow00.md
+++ b/docs/team/fredericchow00.md
@@ -82,15 +82,28 @@ Example Input: `advance n/John Doe p/(John Doe's number)`
 
 Output: `Successfully advanced John Doe`
 
-2. Wrote test cases for RejectCommand
+2. Enhanced `AdvanceCommand` to detect for duplicate interview date and time when 
+advancing an applicant from `APPLIED` to `SHORTLISTED`.
+
+> Example Situation: There is an applicant, Jane Goh, whose status is 
+`SHORTLISTED` with the `InterviewDateTime` of `05-05-2023 18:00`.
+
+Example Input: `advance n/John Doe p/(John Doe's number) d/05-05-2023 18:00`
+
+Output: `There is a clash of interview date and time with Jane Goh!`
+
+- **Test Cases**:
+
+1. Wrote test cases for RejectCommand
 
     - Test cases that covers possible paths taken by `execute(Model model)` and
    `equals()` in `RejectCommand` class.
 
-3. Wrote test cases for RejectCommandParser
+2. Wrote test cases for RejectCommandParser
 
     - Test cases that covers possible paths taken by `parse(String args)` 
    in `RejectCommandParser` class.
+
 
 - **Documentation**:
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,8 +14,8 @@ public class Messages {
     public static final String MESSAGE_INTERVIEW_DATETIME_NOT_REQUIRED = "Interview date and time is not required!";
     public static final String MESSAGE_INTERVIEW_DATETIME_IS_REQUIRED =
             "Please provide an interview date and time! (dd-MM-yyyy HH:mm)";
-    public static final String MESSAGE_PERSON_CANNOT_BE_ADVANCED = "%s cannot be advanced!";
-    public static final String MESSAGE_DUPLICATE_INTERVIEWDATE = "There is a clash of interview dates with %s!";
+    public static final String MESSAGE_DUPLICATE_INTERVIEW_DATE =
+            "There is a clash of interview date and time with %s!";
 
 
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -15,5 +15,7 @@ public class Messages {
     public static final String MESSAGE_INTERVIEW_DATETIME_IS_REQUIRED =
             "Please provide an interview date and time! (dd-MM-yyyy HH:mm)";
     public static final String MESSAGE_PERSON_CANNOT_BE_ADVANCED = "%s cannot be advanced!";
+    public static final String MESSAGE_DUPLICATE_INTERVIEWDATE = "There is a clash of interview dates with %s!";
+
 
 }

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -71,7 +71,7 @@ public class AdvanceCommand extends Command {
         /* this if-statement will check whether the applicant can be advanced and also whether
         the interview datetime input is valid.
         If any exception occurs along the way, then CommandException will be thrown */
-        if (canAdvanceApplicant(model, personToAdvance)
+        if (canAdvanceApplicant(personToAdvance)
                 && isValidInterviewDateInput(model, personToAdvance, this.interviewDateTime)) {
             advancedPerson = createAdvancedPerson(personToAdvance, this.interviewDateTime);
             model.setPerson(personToAdvance, advancedPerson);
@@ -144,10 +144,10 @@ public class AdvanceCommand extends Command {
 
     /**
      * Checks whether applicant can be advanced
-     * @throws CommandException if applicant cannot be advanced any further in the application cycle
      */
-    private boolean canAdvanceApplicant(Model model, Person personToAdvance) throws CommandException {
-        if (!model.advancePerson(personToAdvance)) {
+    private boolean canAdvanceApplicant(Person personToAdvance) throws CommandException{
+        Status status = personToAdvance.getStatus();
+        if (status.equals(Status.ACCEPTED) || status.equals(Status.REJECTED)) {
             throw new CommandException(String.format(MESSAGE_PERSON_CANNOT_BE_ADVANCED,
                     personToAdvance.getName().fullName));
         }

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -145,7 +145,7 @@ public class AdvanceCommand extends Command {
     /**
      * Checks whether applicant can be advanced
      */
-    private boolean canAdvanceApplicant(Person personToAdvance) throws CommandException{
+    private boolean canAdvanceApplicant(Person personToAdvance) throws CommandException {
         Status status = personToAdvance.getStatus();
         if (status.equals(Status.ACCEPTED) || status.equals(Status.REJECTED)) {
             throw new CommandException(String.format(MESSAGE_PERSON_CANNOT_BE_ADVANCED,

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -117,7 +117,7 @@ public class AdvanceCommand extends Command {
      */
     private boolean isValidForAdvanceWithDateTime(Model model, Person personToAdvance,
             InterviewDateTime interviewDateTime) throws CommandException {
-        return personToAdvance.getStatus() == Status.APPLIED && !isDuplicateDateTime(model,
+        return personToAdvance.getStatus().equals(Status.APPLIED) && !isDuplicateDateTime(model,
                 personToAdvance, interviewDateTime);
     }
 
@@ -129,7 +129,7 @@ public class AdvanceCommand extends Command {
      */
     private boolean isDuplicateDateTime(
             Model model, Person personToAdvance, InterviewDateTime interviewDateTime) throws CommandException {
-        Predicate<Person> shortlistedPredicate = person -> (person.getStatus() == Status.SHORTLISTED);
+        Predicate<Person> shortlistedPredicate = person -> (person.getStatus().equals(Status.SHORTLISTED));
         model.refreshListWithPredicate(shortlistedPredicate);
         ObservableList<Person> shortlistedApplicants = model.getFilteredPersonList();
         for (Person applicant : shortlistedApplicants) {

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -117,7 +117,7 @@ public class AdvanceCommand extends Command {
      */
     private boolean isValidForAdvanceWithDateTime(Model model, Person personToAdvance,
             InterviewDateTime interviewDateTime) throws CommandException {
-        return personToAdvance.getStatus().equals(Status.APPLIED) && !isDuplicateDateTime(model,
+        return personToAdvance.getStatus() == Status.APPLIED && !isDuplicateDateTime(model,
                 personToAdvance, interviewDateTime);
     }
 
@@ -129,7 +129,7 @@ public class AdvanceCommand extends Command {
      */
     private boolean isDuplicateDateTime(
             Model model, Person personToAdvance, InterviewDateTime interviewDateTime) throws CommandException {
-        Predicate<Person> shortlistedPredicate = person -> (person.getStatus().equals(Status.SHORTLISTED));
+        Predicate<Person> shortlistedPredicate = person -> (person.getStatus() == Status.SHORTLISTED);
         model.refreshListWithPredicate(shortlistedPredicate);
         ObservableList<Person> shortlistedApplicants = model.getFilteredPersonList();
         for (Person applicant : shortlistedApplicants) {

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -8,15 +8,16 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.note.Note;
-import seedu.address.model.person.*;
+import seedu.address.model.person.InterviewDateTime;
+import seedu.address.model.person.NamePhoneNumberPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Status;
 
 /**
  * Advances an applicant in HMHero.
@@ -127,7 +128,7 @@ public class AdvanceCommand extends Command {
      * @param interviewDateTime new date and time of the interview for the applicant
      */
     private boolean isDuplicateDateTime(
-            Model model, Person personToAdvance, InterviewDateTime interviewDateTime) throws CommandException{
+            Model model, Person personToAdvance, InterviewDateTime interviewDateTime) throws CommandException {
         Predicate<Person> shortlistedPredicate = person -> (person.getStatus() == Status.SHORTLISTED);
         model.refreshListWithPredicate(shortlistedPredicate);
         ObservableList<Person> shortlistedApplicants = model.getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/commands/RejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RejectCommand.java
@@ -90,19 +90,7 @@ public class RejectCommand extends Command {
      */
     private static Person createRejectedPerson(Person personToReject) {
         assert personToReject != null;
-
-        Name updatedName = personToReject.getName();
-        Phone updatedPhone = personToReject.getPhone();
-        Email updatedEmail = personToReject.getEmail();
-        Address updatedAddress = personToReject.getAddress();
-        Status updatedStatus = personToReject.getStatus(); //User not allowed to edit applicant status directly
-        Optional<InterviewDateTime> interviewDateTime = personToReject.getInterviewDateTime();
-        Set<Note> updatedNotes = personToReject.getNotes();
-
-        Person rejectedPerson = new Person(updatedName, updatedPhone, updatedEmail,
-                updatedAddress, updatedStatus, interviewDateTime, updatedNotes);
-        rejectedPerson.rejectPerson();
-        return rejectedPerson;
+        return personToReject.rejectPerson();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RejectCommand.java
@@ -5,21 +5,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.note.Note;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.InterviewDateTime;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.Status;
 
 
 /**

--- a/src/main/java/seedu/address/logic/commands/RejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RejectCommand.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Status;
 
 
 /**
@@ -56,7 +57,7 @@ public class RejectCommand extends Command {
 
         /* this if-statement will check whether the applicant can be rejected.
         If applicant cannot be rejected, CommandException will be thrown */
-        if (canRejectApplicant(model, personToReject)) {
+        if (canRejectApplicant(personToReject)) {
             rejectedPerson = createRejectedPerson(personToReject);
             model.setPerson(personToReject, rejectedPerson);
         }
@@ -68,8 +69,10 @@ public class RejectCommand extends Command {
      * Checks whether applicant can be rejected
      * @throws CommandException if applicant is already rejected
      */
-    private boolean canRejectApplicant(Model model, Person personToReject) throws CommandException {
-        if (!model.rejectPerson(personToReject)) {
+    private boolean canRejectApplicant(Person personToReject) throws CommandException {
+        Status status = personToReject.getStatus();
+
+        if (status.equals(Status.REJECTED)) {
             throw new CommandException(String.format(MESSAGE_PERSON_CANNOT_BE_REJECTED,
                     personToReject.getName().fullName));
         }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -93,25 +93,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
-    /**
-     * Advances {@code target} from this {@code AddressBook}
-     * {@code target} must exist in the address book.
-     */
-    public boolean advancePerson(Person target) {
-        requireNonNull(target);
-
-        return persons.advancePerson(target);
-    }
-
-    /**
-     * Rejects {@code target} from this {@code AddressBook}
-     * {@code target} must exist in the address book.
-     */
-    public boolean rejectPerson(Person target) {
-        requireNonNull(target);
-        return persons.rejectPerson(target);
-    }
-
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,18 +78,6 @@ public interface Model {
     void setPerson(Person target, Person editedPerson);
 
     /**
-     * Advances the given person.
-     * The person must exist in the address book.
-     */
-    boolean advancePerson(Person target);
-
-    /**
-     * Rejects the given person.
-     * The person must exist in the address book.
-     */
-    boolean rejectPerson(Person target);
-
-    /**
      * Refreshes the list after a command.
      */
     void refreshListWithPredicate(Predicate<Person> predicate);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -114,20 +114,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean advancePerson(Person target) {
-        requireNonNull(target);
-
-        return addressBook.advancePerson(target);
-    }
-
-    @Override
-    public boolean rejectPerson(Person target) {
-        requireNonNull(target);
-
-        return addressBook.rejectPerson(target);
-    }
-
-    @Override
     public void refreshListWithPredicate(Predicate<Person> predicate) {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         filteredPersons.setPredicate(predicate);

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Note {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}-]+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\s-]+";
 
     public final String noteName;
 

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import seedu.address.logic.commands.AdvanceCommand;
 import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import seedu.address.logic.commands.AdvanceCommand;
 import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -54,5 +55,12 @@ public class InterviewDateTime {
     @Override
     public String toString() {
         return DateTimeParser.datetimeFormatter(dateTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewDateTime // instanceof handles nulls
+                && dateTime.equals(((InterviewDateTime) other).dateTime)); // state check
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -23,9 +23,9 @@ public class Person {
 
     // Data fields
     private final Address address;
-    private Status status;
+    private final Status status;
     private final Set<Note> notes = new HashSet<>();
-    private Optional<InterviewDateTime> interviewDateTime;
+    private final Optional<InterviewDateTime> interviewDateTime;
 
     /**
      * Every field must be present and not null.
@@ -40,6 +40,22 @@ public class Person {
         this.status = status;
         this.interviewDateTime = interviewDateTime;
         this.notes.addAll(notes);
+    }
+
+    /**
+     * Constructor for updating status of person
+     */
+    public Person(Person person, Status newStatus) {
+        this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
+                newStatus, person.getInterviewDateTime(), person.getNotes());
+    }
+
+    /**
+     * Constructor for updating status and interview date time of person
+     */
+    public Person(Person person, Status newStatus, Optional<InterviewDateTime> interviewDateTime) {
+        this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
+                newStatus, interviewDateTime, person.getNotes());
     }
 
     public Name getName() {
@@ -83,24 +99,14 @@ public class Person {
     }
 
     /**
-     * Sets Status for applicants.
-     * @param status new Status for the applicant.
-     */
-    private void setStatus(Status status) {
-        this.status = status;
-    }
-
-    /**
      * Advances status of applicants, according to application cycle
      */
-    public void advancePerson() {
+    public Person advancePerson(Optional<InterviewDateTime> interviewDateTime) {
         switch (this.status) {
         case APPLIED:
-            setStatus(Status.SHORTLISTED);
-            break;
+            return new Person(this, Status.SHORTLISTED, interviewDateTime);
         case SHORTLISTED:
-            setStatus(Status.ACCEPTED);
-            break;
+            return new Person (this, Status.ACCEPTED);
         default:
             throw new AssertionError("This person's application status cannot be advanced!");
         }
@@ -109,16 +115,8 @@ public class Person {
     /**
      * Changes the status of the applicant to Rejected
      */
-    public void rejectPerson() {
-        this.status = Status.REJECTED;
-    }
-
-    /**
-     * Sets interview dateTime for shortlisted applicants.
-     * @param interviewDateTime Interview dateTime for the applicant.
-     */
-    public void setInterviewDateTime(Optional<InterviewDateTime> interviewDateTime) {
-        this.interviewDateTime = interviewDateTime;
+    public Person rejectPerson() {
+        return new Person(this, Status.REJECTED);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -133,20 +133,6 @@ public class Person {
     }
 
     /**
-     * Returns true if the person status can be advanced otherwise false.
-     */
-    public boolean canAdvance() {
-        return this.status != Status.REJECTED && this.status != Status.ACCEPTED;
-    }
-
-    /**
-     * Returns true if the person status can be rejected otherwise false.
-     */
-    public boolean canReject() {
-        return this.status != Status.REJECTED;
-    }
-
-    /**
      * Returns true if the other person has the same interview date.
      * This is needed as Optional's equals method fails when two different Optional objects
      * are created with same value.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -106,7 +106,7 @@ public class Person {
         case APPLIED:
             return new Person(this, Status.SHORTLISTED, interviewDateTime);
         case SHORTLISTED:
-            return new Person (this, Status.ACCEPTED);
+            return new Person(this, Status.ACCEPTED);
         default:
             throw new AssertionError("This person's application status cannot be advanced!");
         }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -98,24 +98,6 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Advances the equivalent person from the list.
-     * The person must exist in the list.
-     */
-    public boolean advancePerson(Person toAdvance) {
-        requireNonNull(toAdvance);
-        return toAdvance.canAdvance();
-    }
-
-    /**
-     * Rejects the equivalent person from the list.
-     * The person must exist in the list.
-     */
-    public boolean rejectPerson(Person toReject) {
-        requireNonNull(toReject);
-        return toReject.canReject();
-    }
-
-    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -140,16 +140,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean advancePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean rejectPerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void refreshListWithPredicate(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AdvanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AdvanceCommandTest.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.AddressBook;
@@ -82,8 +81,8 @@ public class AdvanceCommandTest {
             advanceCommand.execute(model);
         });
 
-        assertEquals(String.format(AdvanceCommand.MESSAGE_PERSON_CANNOT_BE_ADVANCED, personToAdvance.getName().fullName),
-                exceptionThrown.getMessage());
+        assertEquals(String.format(AdvanceCommand.MESSAGE_PERSON_CANNOT_BE_ADVANCED,
+                personToAdvance.getName().fullName), exceptionThrown.getMessage());
         model.deletePerson(personToAdvance);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -11,8 +10,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AdvanceCommand;
+import seedu.address.logic.commands.RejectCommand;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.testutil.PersonBuilder;
 
 public class AdvanceCommandParserTest {
@@ -24,9 +26,22 @@ public class AdvanceCommandParserTest {
         Person amy = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).build();
         NamePhoneNumberPredicate predicate = new NamePhoneNumberPredicate(amy.getName(), amy.getPhone());
         AdvanceCommand expectedAdvanceCommand = new AdvanceCommand(predicate, Optional.empty());
+
+        // standard preamble
         assertParseSuccess(parser, " n/Amy Bee p/11111111", expectedAdvanceCommand);
+
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n n/Amy Bee \n \t p/11111111  \t", expectedAdvanceCommand);
+
+        // multiple persons - last person accepted (Bob)
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY, expectedAdvanceCommand);
+
+        // one person, multiple phones - last phone accepted
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_BOB + PHONE_DESC_AMY, expectedAdvanceCommand);
+
+        // one person, multiple names - last names accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY, expectedAdvanceCommand);
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
@@ -1,7 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -10,15 +15,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AdvanceCommand;
-import seedu.address.logic.commands.RejectCommand;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
 import seedu.address.testutil.PersonBuilder;
 
 public class AdvanceCommandParserTest {
-    private AdvanceCommandParser parser = new AdvanceCommandParser();
+    private final AdvanceCommandParser parser = new AdvanceCommandParser();
 
     @Test
     public void parse_validArgs_returnsAdvanceCommand() {


### PR DESCRIPTION
## What
Allow `AdvanceCommand` to check whether there are any existing `InterviewDateTime` that clashes with the
current applicants who are `SHORTLISTED` 

## Why
Prevents the user from scheduling two interviews at the same date and time. 

## How
For each advance command involving advancing the applicant from `APPLIED` to `SHORTLISTED`, we filter to the current list of `SHORTLISTED` applicants and checks whether the `InterviewDateTime` that user input clashes with that of the currently `SHORTLISTED` applicants. 

Fix #60 