### PR TITLE
Application date field

### DIFF
--- a/docs/team/fredericchow00.md
+++ b/docs/team/fredericchow00.md
@@ -82,15 +82,28 @@ Example Input: `advance n/John Doe p/(John Doe's number)`
 
 Output: `Successfully advanced John Doe`
 
-2. Wrote test cases for RejectCommand
+2. Enhanced `AdvanceCommand` to detect for duplicate interview date and time when 
+advancing an applicant from `APPLIED` to `SHORTLISTED`.
+
+> Example Situation: There is an applicant, Jane Goh, whose status is 
+`SHORTLISTED` with the `InterviewDateTime` of `05-05-2023 18:00`.
+
+Example Input: `advance n/John Doe p/(John Doe's number) d/05-05-2023 18:00`
+
+Output: `There is a clash of interview date and time with Jane Goh!`
+
+- **Test Cases**:
+
+1. Wrote test cases for RejectCommand
 
     - Test cases that covers possible paths taken by `execute(Model model)` and
    `equals()` in `RejectCommand` class.
 
-3. Wrote test cases for RejectCommandParser
+2. Wrote test cases for RejectCommandParser
 
     - Test cases that covers possible paths taken by `parse(String args)` 
    in `RejectCommandParser` class.
+
 
 - **Documentation**:
 

--- a/docs/team/fredericchow00.md
+++ b/docs/team/fredericchow00.md
@@ -35,7 +35,7 @@ title: <Frederic Chow> Project Portfolio Page
 
 - **Features implemented**
 
-1. Implemented "list" feature that lists out all applicants across all statuses,
+1. Implemented `list` feature that lists out all applicants across all statuses,
    with a statistic that shows the number of applicants in each status
 
 Example Input: `list`
@@ -53,6 +53,9 @@ Shortlisted: 1
 Accepted: 1
 Rejected: 0
 ```
+
+2. Implemented `ApplicationDateTime` class that is an additional field under Person,
+so as to track the date of application for usage in other commands.
 
 - **Enhancements to existing features**:
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,6 +14,8 @@ public class Messages {
     public static final String MESSAGE_INTERVIEW_DATETIME_NOT_REQUIRED = "Interview date and time is not required!";
     public static final String MESSAGE_INTERVIEW_DATETIME_IS_REQUIRED =
             "Please provide an interview date and time! (dd-MM-yyyy HH:mm)";
-    public static final String MESSAGE_PERSON_CANNOT_BE_ADVANCED = "%s cannot be advanced!";
+    public static final String MESSAGE_DUPLICATE_INTERVIEW_DATE =
+            "There is a clash of interview date and time with %s!";
+
 
 }

--- a/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvanceCommand.java
@@ -1,14 +1,16 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSON_CANNOT_BE_ADVANCED;
+import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INTERVIEW_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -32,6 +34,10 @@ public class AdvanceCommand extends Command {
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_DATETIME + "08-03-2023 18:00";
+
+    public static final String MESSAGE_ADVANCE_PERSON_SUCCESS = "Advanced Applicant: %1$s";
+
+    public static final String MESSAGE_PERSON_CANNOT_BE_ADVANCED = "%s's status cannot be advanced!";
 
     private final NamePhoneNumberPredicate predicate;
     private final Optional<InterviewDateTime> interviewDateTime;
@@ -60,15 +66,18 @@ public class AdvanceCommand extends Command {
         }
 
         Person personToAdvance = personList.get(0);
+        Person advancedPerson;
 
         /* this if-statement will check whether the applicant can be advanced and also whether
         the interview datetime input is valid.
         If any exception occurs along the way, then CommandException will be thrown */
         if (canAdvanceApplicant(model, personToAdvance)
-                && isValidInterviewDateInput(personToAdvance, this.interviewDateTime)) {
-            advanceApplicant(model, personToAdvance, this.interviewDateTime);
+                && isValidInterviewDateInput(model, personToAdvance, this.interviewDateTime)) {
+            advancedPerson = createAdvancedPerson(personToAdvance, this.interviewDateTime);
+            model.setPerson(personToAdvance, advancedPerson);
         }
-        return new CommandResult("Successfully advanced " + personToAdvance.getName());
+        model.refreshListWithPredicate(predicate);
+        return new CommandResult(String.format(MESSAGE_ADVANCE_PERSON_SUCCESS, personToAdvance.getName()));
     }
 
     /**
@@ -78,11 +87,12 @@ public class AdvanceCommand extends Command {
      * @param interviewDateTime the interview date-time input
      * @throws CommandException if there is a mismatch of whether interview date-time is required
      */
-    private boolean isValidInterviewDateInput(Person personToAdvance, Optional<InterviewDateTime> interviewDateTime)
-            throws CommandException {
+    private boolean isValidInterviewDateInput(Model model, Person personToAdvance,
+            Optional<InterviewDateTime> interviewDateTime) throws CommandException {
+
         // interviewDateTime is only required if the applicant's status is Applied
         if (interviewDateTime.isPresent()) {
-            if (personToAdvance.getStatus() == Status.APPLIED) {
+            if (isValidForAdvanceWithDateTime(model, personToAdvance, interviewDateTime.get())) {
                 return true;
             } else {
                 throw new CommandException(Messages.MESSAGE_INTERVIEW_DATETIME_NOT_REQUIRED);
@@ -97,6 +107,42 @@ public class AdvanceCommand extends Command {
     }
 
     /**
+     * Checks whether applicant that user wants to advance is of status {@code APPLIED}
+     * Checks whether the interview date time has any clashes with current applicants who have the
+     * status {@code SHORTLISTED}
+     *
+     * @param model current state of the model
+     * @param personToAdvance Applicant that user wants to advance to the next stage in application cycle
+     * @param interviewDateTime date and time of the interview for the applicant
+     */
+    private boolean isValidForAdvanceWithDateTime(Model model, Person personToAdvance,
+            InterviewDateTime interviewDateTime) throws CommandException {
+        return personToAdvance.getStatus() == Status.APPLIED && !isDuplicateDateTime(model,
+                personToAdvance, interviewDateTime);
+    }
+
+
+    /**
+     * Checks with the current list of Shortlisted applicants to see if there are any clashing interview date timings.
+     *
+     * @param interviewDateTime new date and time of the interview for the applicant
+     */
+    private boolean isDuplicateDateTime(
+            Model model, Person personToAdvance, InterviewDateTime interviewDateTime) throws CommandException {
+        Predicate<Person> shortlistedPredicate = person -> (person.getStatus() == Status.SHORTLISTED);
+        model.refreshListWithPredicate(shortlistedPredicate);
+        ObservableList<Person> shortlistedApplicants = model.getFilteredPersonList();
+        for (Person applicant : shortlistedApplicants) {
+            if (applicant.getInterviewDateTime().get().equals(interviewDateTime)) {
+                Predicate<Person> samePersonPredicate = person -> (person.equals(applicant));
+                model.refreshListWithPredicate(samePersonPredicate);
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_INTERVIEW_DATE, applicant.getName()));
+            }
+        }
+        return false;
+    }
+
+    /**
      * Checks whether applicant can be advanced
      * @throws CommandException if applicant cannot be advanced any further in the application cycle
      */
@@ -108,10 +154,13 @@ public class AdvanceCommand extends Command {
         return true;
     }
 
-    private void advanceApplicant(Model model, Person personToAdvance, Optional<InterviewDateTime> interviewDateTime) {
-        personToAdvance.setInterviewDateTime(interviewDateTime);
-        personToAdvance.advancePerson();
-        model.refreshListWithPredicate(predicate);
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToAdvance}
+     */
+    private static Person createAdvancedPerson(Person personToAdvance, Optional<InterviewDateTime> interviewDateTime) {
+        assert personToAdvance != null;
+
+        return personToAdvance.advancePerson(interviewDateTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RejectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RejectCommand.java
@@ -5,21 +5,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.note.Note;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.InterviewDateTime;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.NamePhoneNumberPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.Status;
 
 
 /**
@@ -90,19 +81,7 @@ public class RejectCommand extends Command {
      */
     private static Person createRejectedPerson(Person personToReject) {
         assert personToReject != null;
-
-        Name updatedName = personToReject.getName();
-        Phone updatedPhone = personToReject.getPhone();
-        Email updatedEmail = personToReject.getEmail();
-        Address updatedAddress = personToReject.getAddress();
-        Status updatedStatus = personToReject.getStatus(); //User not allowed to edit applicant status directly
-        Optional<InterviewDateTime> interviewDateTime = personToReject.getInterviewDateTime();
-        Set<Note> updatedNotes = personToReject.getNotes();
-
-        Person rejectedPerson = new Person(updatedName, updatedPhone, updatedEmail,
-                updatedAddress, updatedStatus, interviewDateTime, updatedNotes);
-        rejectedPerson.rejectPerson();
-        return rejectedPerson;
+        return personToReject.rejectPerson();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/Note.java
+++ b/src/main/java/seedu/address/model/note/Note.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Note {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}-]+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\s-]+";
 
     public final String noteName;
 

--- a/src/main/java/seedu/address/model/person/ApplicationDateTime.java
+++ b/src/main/java/seedu/address/model/person/ApplicationDateTime.java
@@ -1,56 +1,45 @@
 package seedu.address.model.person;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import seedu.address.logic.parser.DateTimeParser;
-import seedu.address.logic.parser.exceptions.ParseException;
+
+import static java.util.Objects.requireNonNull;
 
 
 /**
  * Represents a Person's interview date and time in the address book.
  */
 public class ApplicationDateTime {
-    private final LocalDateTime dateTime;
+    private final LocalDateTime applicationDateTime;
 
-    public InterviewDateTime(String dateTime) throws ParseException {
-        this.dateTime = DateTimeParser.parseDateTime(dateTime);
+    /**
+     * Constructor for ApplicationDateTime
+     * @param applicationDateTime LocalDateTime of the current time and date
+     */
+    public ApplicationDateTime(LocalDateTime applicationDateTime) {
+        requireNonNull(applicationDateTime);
+
+        this.applicationDateTime = applicationDateTime;
     }
 
     /**
-     * method to create InterviewDateTime, used in converting from json
-     * @param dateTime String form of dateTime or empty string
-     * @return null if empty String, InterviewDateTime object otherwise
-     * @throws ParseException if dateTime String cannot be parsed
+     * @return LocalDateTime object of the application date and time.
      */
-    public static Optional<InterviewDateTime> createInterviewDateTime(String dateTime) throws ParseException {
-        if (dateTime.equals("")) {
-            return Optional.empty();
-        } else {
-            return Optional.of(new InterviewDateTime(dateTime));
-        }
-    }
-
-    public LocalDateTime getDateTime() {
-        return dateTime;
-    }
-
-    /**
-     * Returns if a given dateTime string is valid
-     * Use before invoking createInterviewDateTime to ensure it does not throw ParseException
-     */
-    public static boolean isValidDateTime(String dateTime) {
-        try {
-            DateTimeParser.parseDateTime(dateTime);
-            return true;
-        } catch (ParseException e) {
-            return false;
-        }
+    public LocalDateTime getApplicationDateTime() {
+        return this.applicationDateTime;
     }
 
     @Override
     public String toString() {
-        return DateTimeParser.datetimeFormatter(dateTime);
+        return DateTimeParser.datetimeFormatter(applicationDateTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ApplicationDateTime // instanceof handles nulls
+                && applicationDateTime.equals(((ApplicationDateTime) other).applicationDateTime)); // state check
     }
 }
 

--- a/src/main/java/seedu/address/model/person/ApplicationDateTime.java
+++ b/src/main/java/seedu/address/model/person/ApplicationDateTime.java
@@ -1,10 +1,11 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.LocalDateTime;
 
 import seedu.address.logic.parser.DateTimeParser;
 
-import static java.util.Objects.requireNonNull;
 
 
 /**

--- a/src/main/java/seedu/address/model/person/ApplicationDateTime.java
+++ b/src/main/java/seedu/address/model/person/ApplicationDateTime.java
@@ -1,0 +1,56 @@
+package seedu.address.model.person;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import seedu.address.logic.parser.DateTimeParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Represents a Person's interview date and time in the address book.
+ */
+public class ApplicationDateTime {
+    private final LocalDateTime dateTime;
+
+    public InterviewDateTime(String dateTime) throws ParseException {
+        this.dateTime = DateTimeParser.parseDateTime(dateTime);
+    }
+
+    /**
+     * method to create InterviewDateTime, used in converting from json
+     * @param dateTime String form of dateTime or empty string
+     * @return null if empty String, InterviewDateTime object otherwise
+     * @throws ParseException if dateTime String cannot be parsed
+     */
+    public static Optional<InterviewDateTime> createInterviewDateTime(String dateTime) throws ParseException {
+        if (dateTime.equals("")) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new InterviewDateTime(dateTime));
+        }
+    }
+
+    public LocalDateTime getDateTime() {
+        return dateTime;
+    }
+
+    /**
+     * Returns if a given dateTime string is valid
+     * Use before invoking createInterviewDateTime to ensure it does not throw ParseException
+     */
+    public static boolean isValidDateTime(String dateTime) {
+        try {
+            DateTimeParser.parseDateTime(dateTime);
+            return true;
+        } catch (ParseException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return DateTimeParser.datetimeFormatter(dateTime);
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -23,7 +23,7 @@ public class InterviewDateTime {
     /**
      * method to create InterviewDateTime, used in converting from json
      * @param dateTime String form of dateTime or empty string
-     * @return null if empty String, InterviewDateTime object otherwise
+     * @return {@code Optional.empty()} if empty String, otherwise returns {@code Optional<InterviewDateTime>}.
      * @throws ParseException if dateTime String cannot be parsed
      */
     public static Optional<InterviewDateTime> createInterviewDateTime(String dateTime) throws ParseException {

--- a/src/main/java/seedu/address/model/person/InterviewDateTime.java
+++ b/src/main/java/seedu/address/model/person/InterviewDateTime.java
@@ -55,4 +55,11 @@ public class InterviewDateTime {
     public String toString() {
         return DateTimeParser.datetimeFormatter(dateTime);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewDateTime // instanceof handles nulls
+                && dateTime.equals(((InterviewDateTime) other).dateTime)); // state check
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,7 +24,7 @@ public class Person {
 
     // Data fields
     private final Address address;
-    private Status status;
+    private final Status status;
     private final Set<Note> notes = new HashSet<>();
     private final ApplicationDateTime applicationDateTime;
     private Optional<InterviewDateTime> interviewDateTime;
@@ -43,6 +43,22 @@ public class Person {
         this.applicationDateTime = LocalDateTime.now();
         this.interviewDateTime = interviewDateTime;
         this.notes.addAll(notes);
+    }
+
+    /**
+     * Constructor for updating status of person
+     */
+    public Person(Person person, Status newStatus) {
+        this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
+                newStatus, person.getInterviewDateTime(), person.getNotes());
+    }
+
+    /**
+     * Constructor for updating status and interview date time of person
+     */
+    public Person(Person person, Status newStatus, Optional<InterviewDateTime> interviewDateTime) {
+        this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
+                newStatus, interviewDateTime, person.getNotes());
     }
 
     public Name getName() {
@@ -86,24 +102,14 @@ public class Person {
     }
 
     /**
-     * Sets Status for applicants.
-     * @param status new Status for the applicant.
-     */
-    private void setStatus(Status status) {
-        this.status = status;
-    }
-
-    /**
      * Advances status of applicants, according to application cycle
      */
-    public void advancePerson() {
+    public Person advancePerson(Optional<InterviewDateTime> interviewDateTime) {
         switch (this.status) {
         case APPLIED:
-            setStatus(Status.SHORTLISTED);
-            break;
+            return new Person(this, Status.SHORTLISTED, interviewDateTime);
         case SHORTLISTED:
-            setStatus(Status.ACCEPTED);
-            break;
+            return new Person(this, Status.ACCEPTED);
         default:
             throw new AssertionError("This person's application status cannot be advanced!");
         }
@@ -112,16 +118,8 @@ public class Person {
     /**
      * Changes the status of the applicant to Rejected
      */
-    public void rejectPerson() {
-        this.status = Status.REJECTED;
-    }
-
-    /**
-     * Sets interview dateTime for shortlisted applicants.
-     * @param interviewDateTime Interview dateTime for the applicant.
-     */
-    public void setInterviewDateTime(Optional<InterviewDateTime> interviewDateTime) {
-        this.interviewDateTime = interviewDateTime;
+    public Person rejectPerson() {
+        return new Person(this, Status.REJECTED);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -25,6 +26,7 @@ public class Person {
     private final Address address;
     private Status status;
     private final Set<Note> notes = new HashSet<>();
+    private final ApplicationDateTime applicationDateTime;
     private Optional<InterviewDateTime> interviewDateTime;
 
     /**
@@ -38,6 +40,7 @@ public class Person {
         this.email = email;
         this.address = address;
         this.status = status;
+        this.applicationDateTime = LocalDateTime.now();
         this.interviewDateTime = interviewDateTime;
         this.notes.addAll(notes);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -40,7 +41,7 @@ public class Person {
         this.email = email;
         this.address = address;
         this.status = status;
-        this.applicationDateTime = LocalDateTime.now();
+        this.applicationDateTime = new ApplicationDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES));
         this.interviewDateTime = interviewDateTime;
         this.notes.addAll(notes);
     }
@@ -87,6 +88,14 @@ public class Person {
      */
     public Set<Note> getNotes() {
         return Collections.unmodifiableSet(notes);
+    }
+
+    /**
+     * Returns the {@code ApplicationDateTime} of the applicant.
+     * @return Application date and time of the applicant.
+     */
+    public ApplicationDateTime getApplicationDateTime() {
+        return applicationDateTime;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AdvanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AdvanceCommandTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Optional;
@@ -13,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -76,36 +81,72 @@ public class AdvanceCommandTest {
             advanceCommand.execute(model);
         });
 
-        assertEquals(String.format(Messages.MESSAGE_PERSON_CANNOT_BE_ADVANCED, personToAdvance.getName().fullName),
-                exceptionThrown.getMessage());
+        assertEquals(String.format(AdvanceCommand.MESSAGE_PERSON_CANNOT_BE_ADVANCED,
+                personToAdvance.getName().fullName), exceptionThrown.getMessage());
         model.deletePerson(personToAdvance);
+    }
+
+    @Test
+    public void execute_duplicateInterviewDateApplicant_failure() throws Exception {
+        Person personToAdvance = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person clashingPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        InterviewDateTime clashingDateTime = new InterviewDateTime("02-03-2023 14:00");
+
+        NamePhoneNumberPredicate namePhonePredicate =
+                new NamePhoneNumberPredicate(personToAdvance.getName(), personToAdvance.getPhone());
+        NamePhoneNumberPredicate clashingNamePhonePredicate =
+                new NamePhoneNumberPredicate(clashingPerson.getName(), clashingPerson.getPhone());
+        AdvanceCommand advanceCommand = new AdvanceCommand(namePhonePredicate, Optional.of(clashingDateTime));
+
+        String expectedMessage = String.format(Messages.MESSAGE_DUPLICATE_INTERVIEW_DATE,
+                clashingPerson.getName());
+        model.refreshListWithPredicate(clashingNamePhonePredicate);
+
+        assertCommandFailure(advanceCommand, model, expectedMessage);
     }
 
     @Test
     public void execute_validShortlistedPerson_shouldAdvanceToAccepted() throws Exception {
-        Person personToAdvance = new PersonBuilder().withStatus(String.valueOf(Status.SHORTLISTED)).build();
-        model.addPerson(personToAdvance);
-        AdvanceCommand advanceCommand = new AdvanceCommand(new NamePhoneNumberPredicate(
-                personToAdvance.getName(), personToAdvance.getPhone()), Optional.empty());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        advanceCommand.execute(model);
+        Person personToAdvance = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        PersonBuilder personInList = new PersonBuilder(personToAdvance);
+        Person advancedPerson = personInList.withStatus("ACCEPTED").build();
+        NamePhoneNumberPredicate namePhonePredicate =
+                new NamePhoneNumberPredicate(advancedPerson.getName(), advancedPerson.getPhone());
+        AdvanceCommand advanceCommand = new AdvanceCommand(namePhonePredicate, Optional.empty());
 
-        assertEquals(Status.ACCEPTED, personToAdvance.getStatus());
-        model.deletePerson(personToAdvance);
+        String expectedMessage = String.format(AdvanceCommand.MESSAGE_ADVANCE_PERSON_SUCCESS,
+                personToAdvance.getName());
+
+        expectedModel.setPerson(personToAdvance, advancedPerson);
+        expectedModel.updateFilteredPersonList(namePhonePredicate);
+
+        assertCommandSuccess(advanceCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_validAppliedPersonWithInterviewDate_shouldAdvanceToShortlisted() throws Exception {
-        Person personToAdvance = new PersonBuilder().withStatus(String.valueOf(Status.APPLIED)).build();
-        model.addPerson(personToAdvance);
-        InterviewDateTime dateTime = new InterviewDateTime("01-01-2023 12:00");
-        AdvanceCommand advanceCommand = new AdvanceCommand(new NamePhoneNumberPredicate(
-                personToAdvance.getName(), personToAdvance.getPhone()), Optional.ofNullable(dateTime));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        advanceCommand.execute(model);
+        Person personToAdvance = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        PersonBuilder personInList = new PersonBuilder(personToAdvance);
+        InterviewDateTime dateTime = new InterviewDateTime("01-01-2023 13:00");
+        Person advancedPerson = personInList.withStatus("SHORTLISTED")
+                .withInterviewDateTime("01-01-2023 13:00").build();
 
-        assertEquals(Status.SHORTLISTED, personToAdvance.getStatus());
-        model.deletePerson(personToAdvance);
+        NamePhoneNumberPredicate namePhonePredicate =
+                new NamePhoneNumberPredicate(advancedPerson.getName(), advancedPerson.getPhone());
+        AdvanceCommand advanceCommand = new AdvanceCommand(namePhonePredicate, Optional.of(dateTime));
+
+        String expectedMessage = String.format(AdvanceCommand.MESSAGE_ADVANCE_PERSON_SUCCESS,
+                personToAdvance.getName());
+
+        expectedModel.setPerson(personToAdvance, advancedPerson);
+        expectedModel.updateFilteredPersonList(namePhonePredicate);
+
+        assertCommandSuccess(advanceCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AdvanceCommandParserTest.java
@@ -1,6 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -16,7 +20,7 @@ import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
 public class AdvanceCommandParserTest {
-    private AdvanceCommandParser parser = new AdvanceCommandParser();
+    private final AdvanceCommandParser parser = new AdvanceCommandParser();
 
     @Test
     public void parse_validArgs_returnsAdvanceCommand() {
@@ -24,9 +28,22 @@ public class AdvanceCommandParserTest {
         Person amy = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).build();
         NamePhoneNumberPredicate predicate = new NamePhoneNumberPredicate(amy.getName(), amy.getPhone());
         AdvanceCommand expectedAdvanceCommand = new AdvanceCommand(predicate, Optional.empty());
+
+        // standard preamble
         assertParseSuccess(parser, " n/Amy Bee p/11111111", expectedAdvanceCommand);
+
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n n/Amy Bee \n \t p/11111111  \t", expectedAdvanceCommand);
+
+        // multiple persons - last person accepted (Bob)
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY, expectedAdvanceCommand);
+
+        // one person, multiple phones - last phone accepted
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_BOB + PHONE_DESC_AMY, expectedAdvanceCommand);
+
+        // one person, multiple names - last names accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY, expectedAdvanceCommand);
+
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/ApplicationDateTimeTest.java
+++ b/src/test/java/seedu/address/model/person/ApplicationDateTimeTest.java
@@ -1,13 +1,13 @@
 package seedu.address.model.person;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
 
 class ApplicationDateTimeTest {
     private static final ApplicationDateTime truncatedApplicationDateTime =

--- a/src/test/java/seedu/address/model/person/ApplicationDateTimeTest.java
+++ b/src/test/java/seedu/address/model/person/ApplicationDateTimeTest.java
@@ -1,0 +1,60 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+class ApplicationDateTimeTest {
+    private static final ApplicationDateTime truncatedApplicationDateTime =
+            new ApplicationDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES));
+    private static final ApplicationDateTime notTruncatedapplicationDateTime =
+            new ApplicationDateTime(LocalDateTime.now());
+
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ApplicationDateTime(null));
+    }
+
+    @Test
+    public void getApplicationDate() {
+        ApplicationDateTime sameApplicationDateTimeTruncated =
+                new ApplicationDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES));
+
+        ApplicationDateTime otherApplicationDateTime =
+                new ApplicationDateTime(LocalDateTime.of(2023, 05, 05, 18, 00));
+
+        // if LocalDateTime is same --> equals
+        assertEquals(truncatedApplicationDateTime.getApplicationDateTime(),
+                sameApplicationDateTimeTruncated.getApplicationDateTime());
+
+        // if LocalDateTime is different --> not equals
+        assertNotEquals(truncatedApplicationDateTime.getApplicationDateTime(),
+                otherApplicationDateTime.getApplicationDateTime());
+
+        // if LocalDateTime is not truncated --> not equals
+        assertNotEquals(truncatedApplicationDateTime.getApplicationDateTime(),
+                notTruncatedapplicationDateTime.getApplicationDateTime());
+    }
+
+    @Test
+    public void equals() {
+        ApplicationDateTime otherApplicationDateTime =
+                new ApplicationDateTime(LocalDateTime.of(2023, 05, 05, 18, 00));
+
+        // different LocalDateTime --> not equals
+        assertNotEquals(truncatedApplicationDateTime, otherApplicationDateTime);
+
+        // same LocalDateTime --> trivially equals to each other
+        assertEquals(truncatedApplicationDateTime, truncatedApplicationDateTime);
+
+        // same LocalDateTime but one is not truncated --> not equals to each other due to milliseconds difference
+        assertNotEquals(truncatedApplicationDateTime, notTruncatedapplicationDateTime);
+    }
+
+}


### PR DESCRIPTION
## What
Implemented `ApplicationDateTime` class and wrote `ApplicationDateTimeTest`

## Why
Allows HMHero to track the application date of applicants when they get added into the application.

Test cases are written to ensure that `ApplicationDateTime` is working according to its business logic.

## How
Add `ApplicationDateTime` field to `Person`. This will allow future implemented commands to track the date and time that the applicant applied to the company.

Adds full path coverage for `ApplicationDateTime`

Fix #64 