### PR TITLE
Enhance find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -17,10 +17,11 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords such as name, phone number or both (case-insensitive) and displays them as a "
+            + "the specified keywords such as name, phone number, note (case-insensitive) and displays them as a "
             + "list with index numbers.\n"
-            + "Parameters: Format 1: KEYWORDS(either NAME or PHONE NUMBER);\n "
-            + "Format 2: n/NAME p/PHONE NUMBER(both must referring to the same person)\n"
+            + "Parameters: Format 1: KEYWORDS(either NAME or PHONE NUMBER)\n "
+            + "Format 2: n/NAME p/PHONE NUMBER note/NOTE_1 note/NOTE_2\n"
+            + "Any combination of prefixes are allowed for Format 2. Using more prefixes narrows down the target. \n"
             + "Example for Format 1: " + COMMAND_WORD + " alice bob charlie OR 12345678\n"
             + "Example for Format 2: " + COMMAND_WORD + "n/alice bob p/12345678";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,13 +2,11 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameAndPhoneContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -26,33 +24,17 @@ public class FindCommand extends Command {
             + "Example for Format 1: " + COMMAND_WORD + " alice bob charlie OR 12345678\n"
             + "Example for Format 2: " + COMMAND_WORD + "n/alice bob p/12345678";
 
-    private NameContainsKeywordsPredicate namePredicate = null;
-    private PhoneContainsKeywordsPredicate phonePredicate = null;
-    private NameAndPhoneContainsKeywordsPredicate nameAndPhoneContainsKeywordsPredicate = null;
+    private final Predicate<Person> findPredicate;
 
-    public FindCommand(NameContainsKeywordsPredicate namePredicate) {
-        this.namePredicate = namePredicate;
-    }
-
-    public FindCommand(PhoneContainsKeywordsPredicate phonePredicate) {
-        this.phonePredicate = phonePredicate;
-    }
-
-    public FindCommand(NameAndPhoneContainsKeywordsPredicate nameAndPhoneContainsKeywordsPredicate) {
-        this.nameAndPhoneContainsKeywordsPredicate = nameAndPhoneContainsKeywordsPredicate;
+    public FindCommand(Predicate<Person> findPredicate) {
+        this.findPredicate = findPredicate;
     }
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (nameAndPhoneContainsKeywordsPredicate != null) {
-            model.updateFilteredPersonList(nameAndPhoneContainsKeywordsPredicate);
-        } else if (namePredicate != null) {
-            model.updateFilteredPersonList(namePredicate);
-        } else {
-            model.updateFilteredPersonList(phonePredicate);
-        }
+        model.updateFilteredPersonList(findPredicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -66,10 +48,6 @@ public class FindCommand extends Command {
             return false;
         }
         FindCommand otherCmd = (FindCommand) other;
-        boolean sameNamePredicate = Objects.equals(namePredicate, otherCmd.namePredicate);
-        boolean samePhonePredicate = Objects.equals(phonePredicate, otherCmd.phonePredicate);
-        boolean sameNamePhonePredicate = Objects.equals(nameAndPhoneContainsKeywordsPredicate,
-                otherCmd.nameAndPhoneContainsKeywordsPredicate);
-        return sameNamePredicate && samePhonePredicate && sameNamePhonePredicate;
+        return this.findPredicate.equals(otherCmd.findPredicate);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -34,7 +34,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, ALLOWED_PREFIXES);
-        Predicate<Person> findPredicate = x -> true; //always false predicate as default
+        Predicate<Person> findPredicate = x -> true; //always true predicate as default
         boolean isPrefixInput = false;
 
         if (arePrefixesPresent(argMultimap, PREFIX_NAME)) {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,27 +1,24 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.NameAndPhoneContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
-
-
+import seedu.address.model.note.Note;
+import seedu.address.model.person.*;
 
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    private static final Prefix[] ALLOWED_PREFIXES = {PREFIX_NAME, PREFIX_PHONE, PREFIX_NOTE};
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -29,23 +26,33 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, ALLOWED_PREFIXES);
+        Predicate<Person> findPredicate = x -> true; //always false predicate as default
+        boolean isPrefixInput = false;
 
-
-
-        if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)) {
-            //Means both applicant's name and phone number are given
-
+        if (arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+            isPrefixInput = true;
             Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
             String[] nameKeywords = name.fullName.split("\\s+");
+            findPredicate = findPredicate.and(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        if (arePrefixesPresent(argMultimap, PREFIX_PHONE)) {
+            isPrefixInput = true;
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
             String[] phoneKeywords = phone.value.split("\\s+");
-            String[] combinedKeywords = Arrays.copyOf(nameKeywords, nameKeywords.length + phoneKeywords.length);
-            System.arraycopy(phoneKeywords, 0, combinedKeywords, nameKeywords.length, phoneKeywords.length);
+            findPredicate = findPredicate.and(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+        }
 
-            return new FindCommand(new NameAndPhoneContainsKeywordsPredicate(Arrays.asList(combinedKeywords)));
+        if (arePrefixesPresent(argMultimap, PREFIX_NOTE)) {
+            isPrefixInput = true;
+            Set<Note> noteList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_NOTE));
+            for (Note n: noteList) {
+                findPredicate = findPredicate.and(new NoteContainsKeywordsPredicate(n.noteName));
+            }
+        }
 
-        } else {
+        if (!isPrefixInput) { //if user did not input any prefix -> name or phone searching
             String trimmedArgs = args.trim();
             if (trimmedArgs.isEmpty()) {
                 throw new ParseException(
@@ -53,7 +60,6 @@ public class FindCommandParser implements Parser<FindCommand> {
             }
 
             String[] keywords = trimmedArgs.split("\\s+");
-
 
             if (keywords.length == 1) {
                 String nameOrPhone = keywords[0];
@@ -64,6 +70,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             }
             return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         }
+
+        return new FindCommand(findPredicate);
+
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -11,7 +13,12 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.note.Note;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NoteContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 
 /**

--- a/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import seedu.address.commons.util.StringUtil;
+
 import java.util.function.Predicate;
 
 /**
@@ -15,7 +17,7 @@ public class NoteContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getNotes().stream().anyMatch(note -> note.noteName.equals(keyword));
+        return person.getNotes().stream().anyMatch(note -> StringUtil.containsWordIgnoreCase(note.noteName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that any of a {@code Person}'s {@code Note} matches the keyword given.
+ */
+
+public class NoteContainsKeywordsPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public NoteContainsKeywordsPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getNotes().stream().anyMatch(note -> note.noteName.equals(keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof NoteContainsKeywordsPredicate
+                && keyword.equals(((NoteContainsKeywordsPredicate) other).keyword));
+    }
+}

--- a/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
@@ -1,8 +1,8 @@
 package seedu.address.model.person;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that any of a {@code Person}'s {@code Note} matches the keyword given.

--- a/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NoteContainsKeywordsPredicate.java
@@ -1,9 +1,6 @@
 package seedu.address.model.person;
 
-import java.util.List;
 import java.util.function.Predicate;
-
-import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that any of a {@code Person}'s {@code Note} matches the keyword given.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -78,7 +78,20 @@ public class Person {
         return interviewDateTime;
     }
 
+    /**
+     * Returns String representation of {@code Optional<InterviewDateTime>}
+     * for conversion to {@code JsonAdaptedPerson}
+     * @return InterviewDateTime as String
+     */
     public String getInterviewDateTimeString() {
+        return interviewDateTime.map(InterviewDateTime::toString).orElse("");
+    }
+
+    /**
+     * Returns a String to be displayed in the UI
+     * @return desired String to be displayed for InterviewDateTime
+     */
+    public String getInterviewDateTimeDisplay() {
         if (this.getStatus() == Status.SHORTLISTED) {
             return interviewDateTime.map(InterviewDateTime::toString).orElse("");
         } else {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -79,7 +79,11 @@ public class Person {
     }
 
     public String getInterviewDateTimeString() {
-        return interviewDateTime.map(InterviewDateTime::toString).orElse("");
+        if (this.getStatus() == Status.SHORTLISTED) {
+            return interviewDateTime.map(InterviewDateTime::toString).orElse("");
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -104,7 +104,6 @@ public class Person {
     }
 
     /**
-
      * Returns a String to be displayed in the UI
      * @return desired String to be displayed for InterviewDateTime
      */
@@ -117,15 +116,6 @@ public class Person {
     }
 
     /**
-     * Sets Status for applicants.
-     * @param status new Status for the applicant.
-     */
-    private void setStatus(Status status) {
-        this.status = status;
-    }
-
-    /**
-
      * Advances status of applicants, according to application cycle
      */
     public Person advancePerson(Optional<InterviewDateTime> interviewDateTime) {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -56,7 +56,7 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        status.setText(person.getStatus().name() + " " + person.getInterviewDateTimeString());
+        status.setText(person.getStatus().name() + " " + person.getInterviewDateTimeDisplay());
         person.getNotes().stream()
                 .sorted(Comparator.comparing(note -> note.noteName))
                 .forEach(note -> tags.getChildren().add(new Label(note.noteName)));


### PR DESCRIPTION
## What
Add function in find command parser to allow searching for applicants based on note.
Improve code quality of find command.

## Why
Allow hiring managers to find applicants with specific skillsets that are relevant to the job.

## How
By replacing all the fields in `FindCommand` with `Predicate<Person>`, subsequent enhancements to find command only requires `FindCommandParser` to add on to the predicate using `Predicate<T>`'s `or` `and` methods, rather than adding new fields into `FindCommand`.

To Do: update and add more test cases for `FindCommand`

Fix #62 