### PR TITLE
Change equality checker for the Person class

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -152,8 +152,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
+     * Returns true if both persons have the same name and phone number.
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {
@@ -161,7 +160,8 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone());
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -31,8 +31,8 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+        // same name and phone, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withNotes(VALID_NOTE_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 


### PR DESCRIPTION
## What
Updates `Person` class's equality checker to only equate two `Person` instances as equal when their name and phone number are the same/

## Why
Two `Person` should only be considered duplicates when their name and phone number are identical.

## How
By changing the `isSamePerson` method in the `Person` class to also check for the phone number when checking for equality of two instances of Person.

This PR also edits the test case for`PersonTest` to reflect this new condition check.

Fixes #100 