### PR TITLE
PE-D: Fix typo and numeric names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.util.SortByInterviewDate;
  */
 public class RemindCommand extends Command {
     public static final String COMMAND_WORD = "remind";
-    public static final String MESSAGE_SUCCESS_FORMAT_WITH_APPLICANTS = "Listed all applicants that are have an"
+    public static final String MESSAGE_SUCCESS_FORMAT_WITH_APPLICANTS = "Listed all applicants that have an "
             + "interview in the next three days!";
 
     public static final String MESSAGE_SUCCESS_FORMAT_WITHOUT_APPLICANTS = "There are no upcoming interviews "

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[a-zA-Z ]+$";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z]+[a-zA-Z ]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphabets and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z ]+$";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,12 +29,13 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("12345")); // numbers only
+        assertFalse(Name.isValidName("peter the 2nd")); // alphanumeric characters
+        assertFalse(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+
     }
 }


### PR DESCRIPTION
## What
Fix typo in remind message success
Enforce Name to be alphabets and spaces only.

## How
Changed `isValidName` method in `Name` class.

Fix #130 #160 #166 