### PR TITLE
Fix Invalid Command Error for FindCommand

### DIFF
--- a/docs/team/bofeng1999.md
+++ b/docs/team/bofeng1999.md
@@ -92,15 +92,7 @@ Here are the list of all applicants:
 3. Joe Doe (Rejected) 91234321
 ```
 
-(**This part can change according to your contributions**)
-
-Example
-
-- to be added soon
-
 (**Code contributions**)
-
-Example
 
 - **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=bofeng1999&breakdown=true)
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -17,12 +17,12 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords such as name, phone number, note (case-insensitive) and displays them as a "
+            + "the specified keywords such as name(case-insensitive) or phone number displays them as a "
             + "list with index numbers.\n\n"
             + "Parameters: n/NAME p/PHONE NUMBER\n"
             + "Providing just one of name or phone prefix is sufficient.\n"
             + "Providing both name and phone prefixes narrows down the scope.\n\n"
-            + "Example: " + COMMAND_WORD + "n/alice p/98752354";
+            + "Example: " + COMMAND_WORD + " n/alice p/98752354";
 
     private final Predicate<Person> findPredicate;
 


### PR DESCRIPTION
What
Fix typo in invalid command format message for FindCommand. 
Include my contribution.

How
Remove `note` from FindCommand and put a spacing for example provided.

Fix https: https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/126 https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/132 https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/135 https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/148 https://github.com/AY2223S2-CS2103T-W14-4/tp/issues/162